### PR TITLE
PSREGOV-672:Adding AdditionalStatistics & IncludeMetrics to template

### DIFF
--- a/stacks/aws-metric-streams-client/template.yml
+++ b/stacks/aws-metric-streams-client/template.yml
@@ -130,3 +130,10 @@ Resources:
       IncludeLinkedAccountsMetrics: true
       RoleArn: !GetAtt MetricStreamsRole.Arn
       OutputFormat: 'opentelemetry0.7'
+      StatisticsConfigurations:
+        - AdditionalStatistics:
+            - p95
+            - p99
+          IncludeMetrics:
+            - MetricName: Latency
+              Namespace: AWS/ApiGateway


### PR DESCRIPTION
Adding AdditionalStatistics & IncludeMetrics to template

```
diff --git a/stacks/aws-metric-streams-client/template.yml b/stacks/aws-metric-streams-client/template.yml
index 199e0f9..68cc853 100644
--- a/stacks/aws-metric-streams-client/template.yml
+++ b/stacks/aws-metric-streams-client/template.yml
@@ -130,3 +130,10 @@ Resources:
       IncludeLinkedAccountsMetrics: true
       RoleArn: !GetAtt MetricStreamsRole.Arn
       OutputFormat: 'opentelemetry0.7'
+      StatisticsConfigurations:
+        - AdditionalStatistics:
+            - p95
+            - p99
+          IncludeMetrics:
+            - MetricName: Latency
+              Namespace: AWS/ApiGateway
```