### PR TITLE
PSREGOV-672 :adding the AdditionalStatistics and Include Metrics to t…

### DIFF
--- a/stacks/aws-metric-streams-client/template.yml
+++ b/stacks/aws-metric-streams-client/template.yml
@@ -130,3 +130,10 @@ Resources:
       IncludeLinkedAccountsMetrics: true
       RoleArn: !GetAtt MetricStreamsRole.Arn
       OutputFormat: 'opentelemetry0.7'
+      StatisticsConfigurations:
+        - AdditionalStatistics:
+            - p95
+            - p99
+          IncludeMetrics:
+            - MetricName: Latency
+              Namespace: AWS/ApiGateway


### PR DESCRIPTION

```
diff --git a/stacks/aws-metric-streams-client/template.yml b/stacks/aws-metric-streams-client/template.yml
index 199e0f9..6d1878d 100644
--- a/stacks/aws-metric-streams-client/template.yml
+++ b/stacks/aws-metric-streams-client/template.yml
@@ -130,3 +130,10 @@ Resources:
       IncludeLinkedAccountsMetrics: true
       RoleArn: !GetAtt MetricStreamsRole.Arn
       OutputFormat: 'opentelemetry0.7'
+      StatisticsConfigurations:
+        - AdditionalStatistics:
+            - p95
+            - p99
+          IncludeMetrics:
+            - MetricName: Latency
+              Namespace: AWS/ApiGateway
```