### PR TITLE
Troubleshoot-OneAgent-Upgrade-Error

### DIFF
--- a/.github/workflows/nonprod-deploy.yaml
+++ b/.github/workflows/nonprod-deploy.yaml
@@ -27,6 +27,10 @@ jobs:
           RELEASE_VERSION=$(cat ./lambdalayer/one-agent-version/VERSION)
           echo "Release Verison is $RELEASE_VERSION"
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Verify Assumed Role
+        run: aws sts get-caller-identity
+
       - name: Run Deploy Layer Nonprod
         run: |
           echo "Deploying $RELEASE_VERSION to the $ENV layer."


### PR DESCRIPTION
After Upgrading Dynatrace OneAgent to VERSION 1.311 got this GitHub Action Workflow [error](https://github.com/govuk-one-login/observability-infrastructure/actions/runs/14775614929/job/41483227201)

Adding **aws sts get-caller-identity** to GitHub Actions to verify the assumed role before confirming it has the necessary **lambda:ListLayerVersions** permission.