### PR TITLE
Adding_Archived_Dockerfiles_of_test_Repo

### DIFF
--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_17a8a6ba43503f8b8643289a6f3d5a47ab80e071_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_17a8a6ba43503f8b8643289a6f3d5a47ab80e071_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_353e8a8166330e3b3a9175268438b98e6b7c3432_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_353e8a8166330e3b3a9175268438b98e6b7c3432_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_40dbab6c3414e11feb2207b5553fa5a39bbe400a_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_40dbab6c3414e11feb2207b5553fa5a39bbe400a_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_46afb935c51a0988106815da00359d591d04e556_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_46afb935c51a0988106815da00359d591d04e556_Dockerfile
@@ -1,0 +1,8 @@
+FROM node
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_5d92c85bbc6b37773de491e364ad25902cd1b8a1_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_5d92c85bbc6b37773de491e364ad25902cd1b8a1_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_84f553221df0706b3f3cc40cc2ee6016cfbdc3aa_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_84f553221df0706b3f3cc40cc2ee6016cfbdc3aa_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_9155ad452d5f0e180cfa17483e1b774b4e23e8b4_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_9155ad452d5f0e180cfa17483e1b774b4e23e8b4_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_99dda7fc13ced76791992849c84c679cb405f8e6_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_99dda7fc13ced76791992849c84c679cb405f8e6_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_9c5a5d1147e354331e8f48ed62bb6f810ddd00e4_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_9c5a5d1147e354331e8f48ed62bb6f810ddd00e4_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_a1d7b553278c437905da0468ce26a1b7814cdd79_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_a1d7b553278c437905da0468ce26a1b7814cdd79_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_a718374d351eb0d916cef873e8c21e25b5d69a1a_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_a718374d351eb0d916cef873e8c21e25b5d69a1a_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_a74d3cea418628fa487a53cafcb31e08b17bd3f3_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_a74d3cea418628fa487a53cafcb31e08b17bd3f3_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_bee5a3dd9ad109fdc32c6516ef9cc8b5da22bb52_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_bee5a3dd9ad109fdc32c6516ef9cc8b5da22bb52_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_c266b2c4c1dd3ca573e99e42a7c7f3f7c0d55d68_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_c266b2c4c1dd3ca573e99e42a7c7f3f7c0d55d68_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_cb6b5e0eaaa43e85748462841fd5bf1c236893f3_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_cb6b5e0eaaa43e85748462841fd5bf1c236893f3_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_cbef0a4c62017eb839757aff8f037ec93825d082_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_cbef0a4c62017eb839757aff8f037ec93825d082_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_ce3b6942bfcc6ebff23c10acafa63ba25eb53e50_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_ce3b6942bfcc6ebff23c10acafa63ba25eb53e50_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_dd68b8183e9d6c5301666be1c751323b8892773a_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_dd68b8183e9d6c5301666be1c751323b8892773a_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_e09e5e4021e1508a4eeb2de8d56221c80df15ef3_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_e09e5e4021e1508a4eeb2de8d56221c80df15ef3_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_f0071955c38c7a6bdcb5260d716278f890d948f8_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_f0071955c38c7a6bdcb5260d716278f890d948f8_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]

--- a/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_f483a0b75492116b452d184ca505d34fb2a8c790_Dockerfile
+++ b/Archived_Dockerfiles/test-app-container-registry-containerrepository-pw9xsc3x8pb8_f483a0b75492116b452d184ca505d34fb2a8c790_Dockerfile
@@ -1,0 +1,10 @@
+FROM node
+COPY --from=nbg00813.live.dynatrace.com/linux/oneagent-codemodules:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
+COPY . .
+
+RUN npm ci
+RUN npm run build
+
+CMD [ "node", "index.js" ]


### PR DESCRIPTION
As the [PSREGOV-2541](https://govukverify.atlassian.net/browse/PSREGOV-2541) states the **test-app-container-registry-containerrepository-pw9xsc3x8bp8** repo in the **di-observability-dev** account contains **CRITICAL** and **HIGH** vulnerabilities flagged by Security team, therefore the repo going to be archived in here before it'll be deleted.

[PSREGOV-2541]: https://govukverify.atlassian.net/browse/PSREGOV-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ