### PR TITLE
feat: enable Firehose error logging for metric latency audit

### DIFF
--- a/infrastructure/non-production/aws-metric-streams-client/template.yaml
+++ b/infrastructure/non-production/aws-metric-streams-client/template.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Infrastracture for CloudWatch Metric Streams and delivering to Dynatrace
+Description: Infrastructure for CloudWatch Metric Streams and delivering to Dynatrace
 
 Parameters:
   FirehoseHttpDeliveryEndpoint:
@@ -113,6 +113,10 @@ Resources:
     Properties:
       DeliveryStreamType: DirectPut
       HttpEndpointDestinationConfiguration:
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref FirehoseErrorLogGroup
+          LogStreamName: HttpDelivery
         BufferingHints:
           IntervalInSeconds: 60
           SizeInMBs: 3
@@ -133,6 +137,13 @@ Resources:
         S3Configuration:
           BucketARN: !GetAtt FailedDataBucket.Arn
           RoleARN: !GetAtt FailedDataBucketRole.Arn
+
+  FirehoseErrorLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      # Using Environment instead of Firehose Name to break Circular Dependency
+      LogGroupName: !Sub /aws/kinesisfirehose/metric-stream-${Environment}-errors
+      RetentionInDays: 7
 
   FailedDataBucketPolicy:
     Type: AWS::IAM::Policy
@@ -157,7 +168,12 @@ Resources:
                 - ''
                 - - 'arn:aws:s3:::'
                   - !Ref FailedDataBucket
-                  - '*'
+                  - '/*'
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Resource: !GetAtt FirehoseErrorLogGroup.Arn
 
   FailedDataBucket:
     Type: AWS::S3::Bucket

--- a/infrastructure/non-production/aws-metric-streams-client/template.yaml
+++ b/infrastructure/non-production/aws-metric-streams-client/template.yaml
@@ -144,6 +144,7 @@ Resources:
       # Using Environment instead of Firehose Name to break Circular Dependency
       LogGroupName: !Sub /aws/kinesisfirehose/metric-stream-${Environment}-errors
       RetentionInDays: 7
+      KmsKeyId: !GetAtt KMSKey.Arn
 
   FailedDataBucketPolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
**Objective**
Enable `CloudWatchLoggingOptions` to isolate the root cause of 60-minute metric rejections.

**Key Changes**

- **Resource:** Added `FirehoseErrorLogGroup` with **7-day retention**.
- **Configuration:** Enabled error logging in `HttpEndpointDestinationConfiguration`.
- **IAM:** Scoped `logs:PutLogEvents` permissions to the Firehose delivery role.
- **Fix:** Resolved a **circular dependency** by decoupling the Log Group name from the Firehose resource ID via the
  `${Environment}` parameter.

**Technical Impact**
Exposes `arrivalTimestamp` metadata, allowing us to distinguish between **Ingress Lag** (Source-to-Firehose) and **Transport Lag** (Firehose Retry Buffer).

**Validation**

- cfn-lint validated.
- Resource circularity resolved.