### PR TITLE
Psregov 3840/codepipeline params passed as env vars

### DIFF
--- a/infrastructure/gitsync-core/codepipeline/gitsync-core-pipeline.yaml
+++ b/infrastructure/gitsync-core/codepipeline/gitsync-core-pipeline.yaml
@@ -1,6 +1,9 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
+  AWSRegion:
+    Type: String
+    Default: eu-west-2
   ConnectionArn:
     Type: String
   Environment:
@@ -16,9 +19,27 @@ Parameters:
   GitHubRepoName:
     Type: String
     Default: "observability-infrastructure"
+  KeySpec:
+    Type: String
+    Default: SYMMETRIC_DEFAULT
+  KeyUsage:
+    Type: String
+    Default: ENCRYPT_DECRYPT
   PipelineName:
     Type: String
     Default: codepipeline-gitsync-core-pipeline
+  SecretName:
+    Type: String
+  SecretsDeletionPolicy:
+    Type: String
+    Default: Retain
+  SecretsUpdateReplacePolicy:
+    Type: String
+    Default: Retain
+  SlackChannelId:
+    Type: String
+  SlackWorkspaceId:
+    Type: String
   WorkingDir:
     Type: String
     Description: Working directory for IaC
@@ -229,11 +250,36 @@ Resources:
         Type: CODEPIPELINE
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub infrastructure/gitsync-core/step-0/env/${Environment}/build-spec.yaml
+        BuildSpec: |
+          version: 0.2
+          phases:
+            build:
+              commands:
+                - cd infrastructure/gitsync-core/step-0
+                - ./deploy.sh
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: ENVIRONMENT
+            Value: !Ref Environment
+          - Name: KEYSPEC
+            Value: !Ref KeySpec
+          - Name: KEYUSAGE
+            Value: !Ref KeyUsage
+          - Name: UPDATE_REPLACE_POLICY
+            Value: !Ref SecretsUpdateReplacePolicy
+          - Name: DELETION_POLICY
+            Value: !Ref SecretsDeletionPolicy
+          - Name: REGION
+            Value: !Ref AWSRegion
+          - Name: REPONAME
+            Value: !Ref GitHubRepoName
+          - Name: STACK_NAME
+            Value: Gitsync-core-step-0
+          - Name: SECRETNAME
+            Value: !Ref SecretName
       Name: 'gitsync-core-pipeline-step-0'
       ServiceRole: !Ref CodeBuildServiceRole
 
@@ -244,11 +290,32 @@ Resources:
         Type: CODEPIPELINE
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub infrastructure/gitsync-core/step-1/env/${Environment}/build-spec.yaml
+        BuildSpec: |
+            version: 0.2
+            phases:
+              build:
+                commands:
+                  - cd infrastructure/gitsync-core/step-1
+                  - ./deploy.sh
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: BRANCHNAME
+            Value: !Ref GitHubBranch
+          - Name: CONNECTIONARN
+            Value: !Ref ConnectionArn
+          - Name: ENVIRONMENT
+            Value: !Ref Environment
+          - Name: STACK_NAME
+            Value: Gitsync-core-step-1
+          - Name: REGION
+            Value: !Ref AWSRegion
+          - Name: REPONAME
+            Value: !Ref GitHubRepoName
+          - Name: SECRETNAME
+            Value: !Ref SecretName
       Name: 'gitsync-core-pipeline-step-1'
       ServiceRole: !Ref CodeBuildServiceRole
 
@@ -259,11 +326,24 @@ Resources:
         Type: CODEPIPELINE
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub infrastructure/gitsync-core/step-2/env/${Environment}/build-spec.yaml
+        BuildSpec: |
+          version: 0.2
+          phases:
+            build:
+              commands:
+                - cd infrastructure/gitsync-core/step-2
+                - ./deploy.sh
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: STACK_NAME
+            Value: GitSyncNotifications-Event-Rules
+          - Name: REGION
+            Value: !Ref AWSRegion
+          - Name: REPONAME
+            Value: !Ref GitHubRepoName
       Name: 'gitsync-core-pipeline-step-2'
       ServiceRole: !Ref CodeBuildServiceRole
 
@@ -274,11 +354,30 @@ Resources:
         Type: CODEPIPELINE
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub infrastructure/gitsync-core/step-3/env/${Environment}/build-spec.yaml
+        BuildSpec: |
+          version: 0.2
+          phases:
+            build:
+              commands:
+                - cd infrastructure/gitsync-core/step-3
+                - ./deploy.sh
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: EVENT_RULES_STACK_NAME
+            Value: GitSyncNotifications-Event-Rules
+          - Name: REGION
+            Value: !Ref AWSRegion
+          - Name: REPONAME
+            Value: !Ref GitHubRepoName
+          - Name: STACK_NAME
+            Value: GitSyncNotifications-Slack-Integration
+          - Name: SLACK_CHANNEL_ID
+            Value: !Ref SlackChannelId
+          - Name: SLACK_WORKSPACE_ID
+            Value: !Ref SlackWorkspaceId
       Name: 'gitsync-core-pipeline-step-3'
       ServiceRole: !Ref CodeBuildServiceRole
 

--- a/infrastructure/gitsync-core/codepipeline/parameters/development.yaml
+++ b/infrastructure/gitsync-core/codepipeline/parameters/development.yaml
@@ -1,7 +1,17 @@
 parameters:
+  AWSRegion: eu-west-2
   Environment: development
   ConnectionName: GDS-GitHub-Connection
+  GitHubBranch: PSREGOV-3840/codepipeline-params-passed-as-env-vars  # <-- change this to your feature branch while testing in development
   GitHubRepoName: observability-infrastructure
-  GitHubBranch: main  # <-- change this to your feature branch while testing in development
   PipelineName: codepipeline-gitsync-core-pipeline
-  WorkingDir: infrastructure/gitsync-core/non-production
+  WorkingDir: placeholder  # not currently in use until step-x/env/ folders can be retired
+  # extra params needed to replace inline build-spec definitions:
+  KeySpec: SYMMETRIC_DEFAULT  # default
+  KeyUsage:  ENCRYPT_DECRYPT  # default
+  GitHubOwner: govuk-one-login  # default
+  SecretsDeletionPolicy: Retain  # default
+  SecretName: DynatraceSecretsV2
+  SecretsUpdateReplacePolicy: Retain  # default
+  SlackChannelId: C06PP0YR7PB  # dev-specific
+  SlackWorkspaceId: T8GT9416G

--- a/infrastructure/gitsync-core/step-0/deploy.sh
+++ b/infrastructure/gitsync-core/step-0/deploy.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 # This script deploys the core gitsync infrastructure. And regional infrastructure in eu-west-2
 
-STACK_NAME="$1-step-0"
-ENVIRONMENT=$2
-REGION="eu-west-2"
-REPONAME=$3
-SECRETNAME=$4
-
 echo "INFO: deploying Secrets Manager stack"
 aws cloudformation deploy \
-  --region $REGION \
+  --region "$REGION" \
   --stack-name "$STACK_NAME" \
   --template-file template.yaml \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameter-overrides \
     Environment="${ENVIRONMENT}" \
     RepositoryName="${REPONAME}" \
-    SecretName="${SECRETNAME}"
+    SecretName="${SECRETNAME}" \
+    KeySpec="${KEYSPEC}" \
+    KeyUsage="${KEYUSAGE}" \
+    DeletionPolicy="${DELETION_POLICY}" \
+    UpdateReplacePolicy="${UPDATE_REPLACE_POLICY}"
 
 echo "STATUS: Stack deploy complete."
 echo "INFO: Scanning stack health."
@@ -26,7 +24,7 @@ echo "INFO: Scanning stack health."
 while true; do
   STATUS=$(aws cloudformation describe-stacks \
     --stack-name "$STACK_NAME" \
-    --region $REGION \
+    --region "$REGION" \
     --query "Stacks[0].StackStatus" \
     --output text)
 
@@ -39,14 +37,14 @@ while true; do
 
     aws cloudformation delete-stack \
       --stack-name "$STACK_NAME" \
-      --region $REGION
+      --region "$REGION"
 
     echo "Stack deletion initiated. Waiting for deletion to complete..."
 
     # Wait for the stack deletion to complete
     aws cloudformation wait stack-delete-complete \
       --stack-name "$STACK_NAME" \
-      --region $REGION
+      --region "$REGION"
 
     echo "Stack deletion completed."
     exit 1

--- a/infrastructure/gitsync-core/step-0/env/development/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-0/env/development/build-spec.yaml
@@ -2,5 +2,6 @@ version: 0.2
 phases:
   build:
     commands:
-      - cd infrastructure/gitsync-core/step-0
-      - ./deploy.sh Gitsync-core development observability-infrastructure DynatraceSecretsV2
+      echo "not used"
+      # - cd infrastructure/gitsync-core/step-0
+      # - ./deploy.sh Gitsync-core development observability-infrastructure DynatraceSecretsV2

--- a/infrastructure/gitsync-core/step-0/env/development/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-0/env/development/build-spec.yaml
@@ -1,7 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      echo "not used"
-      # - cd infrastructure/gitsync-core/step-0
-      # - ./deploy.sh Gitsync-core development observability-infrastructure DynatraceSecretsV2

--- a/infrastructure/gitsync-core/step-0/env/non-production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-0/env/non-production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-0
-      - ./deploy.sh Gitsync-core non-production observability-infrastructure DynatraceSecretsV2

--- a/infrastructure/gitsync-core/step-0/env/production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-0/env/production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-0
-      - ./deploy.sh Gitsync-core production observability-infrastructure DynatraceSecretsV2

--- a/infrastructure/gitsync-core/step-1/deploy.sh
+++ b/infrastructure/gitsync-core/step-1/deploy.sh
@@ -1,21 +1,6 @@
 #!/bin/bash
 # This script deploys the core gitsync infrastructure. And regional infrastructure in eu-west-2
 
-STACK_NAME=$1
-ENVIRONMENT=$2
-CONNECTIONNAME=$3
-REGION="eu-west-2"
-BRANCHNAME=$4
-REPONAME=$5
-SECRETNAME=$6
-
-echo "INFO: collecting CodeConnection ARN"
-CONNECTIONARN=$(
-  aws codestar-connections list-connections \
-    --query "Connections[?ConnectionName=='${CONNECTIONNAME}'].ConnectionArn" \
-    --output text \
-    --region eu-west-2)
-
 echo "INFO: Using the CodeConnection: (${CONNECTIONARN})"
 
 if [[ -n "$SECRETNAME" ]]; then
@@ -29,28 +14,28 @@ if [[ -n "$SECRETNAME" ]]; then
 
   echo "INFO: deploying Git sync configuration"
   aws cloudformation deploy \
-    --region $REGION \
-    --stack-name $STACK_NAME-step-1 \
+    --region "$REGION" \
+    --stack-name "$STACK_NAME" \
     --template-file template.yaml \
     --capabilities CAPABILITY_NAMED_IAM \
     --parameter-overrides \
-      CTEnvironment=${ENVIRONMENT} \
-      CodeStarConnection=${CONNECTIONARN} \
-      BranchName=${BRANCHNAME} \
-      RepositoryName=${REPONAME} \
-      SecretStoreArn=${SECRETARN}
+      CTEnvironment="${ENVIRONMENT}" \
+      CodeStarConnection="${CONNECTIONARN}" \
+      BranchName="${BRANCHNAME}" \
+      RepositoryName="${REPONAME}" \
+      SecretStoreArn="${SECRETARN}"
 else
   echo "INFO: deploying Git sync configuration"
   aws cloudformation deploy \
-    --region $REGION \
-    --stack-name $STACK_NAME-step-1 \
+    --region "$REGION" \
+    --stack-name "$STACK_NAME" \
     --template-file template.yaml \
     --capabilities CAPABILITY_NAMED_IAM \
     --parameter-overrides \
-      CTEnvironment=${ENVIRONMENT} \
-      CodeStarConnection=${CONNECTIONARN} \
-      BranchName=${BRANCHNAME} \
-      RepositoryName=${REPONAME}
+      CTEnvironment="${ENVIRONMENT}" \
+      CodeStarConnection="${CONNECTIONARN}" \
+      BranchName="${BRANCHNAME}" \
+      RepositoryName="${REPONAME}"
 fi
 echo "STATUS: Stack deploy complete."
 echo "INFO: Scanning stack health."
@@ -59,8 +44,8 @@ echo "INFO: Scanning stack health."
 # Poll the status until it reaches a completion or failure state
 while true; do
   STATUS=$(aws cloudformation describe-stacks \
-    --stack-name $STACK_NAME-step-1 \
-    --region $REGION \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
     --query "Stacks[0].StackStatus" \
     --output text)
 
@@ -72,15 +57,15 @@ while true; do
     echo "Attempting to delete the failed stack..."
 
     aws cloudformation delete-stack \
-      --stack-name $STACK_NAME-step-1 \
-      --region $REGION
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
 
     echo "Stack deletion initiated. Waiting for deletion to complete..."
 
     # Wait for the stack deletion to complete
     aws cloudformation wait stack-delete-complete \
-      --stack-name $STACK_NAME-step-1 \
-      --region $REGION
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
 
     echo "Stack deletion completed."
     exit 1

--- a/infrastructure/gitsync-core/step-1/env/development/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-1/env/development/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-1
-      - ./deploy.sh Gitsync-core development GDS-GitHub-Connection main observability-infrastructure DynatraceSecretsV2

--- a/infrastructure/gitsync-core/step-1/env/non-production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-1/env/non-production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-1
-      - ./deploy.sh Gitsync-core non-production GDS-GitHub-Connection main observability-infrastructure DynatraceSecretsV2

--- a/infrastructure/gitsync-core/step-1/env/production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-1/env/production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-1
-      - ./deploy.sh Gitsync-core production GDS-GitHub-Connection main observability-infrastructure DynatraceSecretsV2

--- a/infrastructure/gitsync-core/step-2/deploy.sh
+++ b/infrastructure/gitsync-core/step-2/deploy.sh
@@ -2,20 +2,15 @@
 # This script iterates over the regions array and deploys the notifications-rule
 # template per specified region.
 
-STACK_NAME=$1
-REGION=$2
-REPONAME=$3
-
 echo "INFO: deploying SNS notification rules configuration"
-echo "INFO: executing cloudformation deploy for region: $region"
+echo "INFO: executing cloudformation deploy for region: $REGION"
 aws cloudformation deploy \
-  --region $REGION \
+  --region "$REGION" \
   --template-file notification-rules.yaml \
-  --stack-name $STACK_NAME-Event-Rules \
+  --stack-name "$STACK_NAME" \
   --capabilities CAPABILITY_IAM \
   --parameter-overrides \
-    GitHubRepoName=${REPONAME}
-
+    GitHubRepoName="${REPONAME}"
 
 echo "STATUS: Stack deploy complete."
 echo "INFO: Scanning stack health."
@@ -25,8 +20,8 @@ echo "INFO: Scanning stack health."
 
 while true; do
   STATUS=$(aws cloudformation describe-stacks \
-    --stack-name $STACK_NAME-Event-Rules \
-    --region $REGION \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
     --query "Stacks[0].StackStatus" \
     --output text)
 
@@ -38,15 +33,15 @@ while true; do
     echo "Attempting to delete the failed stack..."
 
     aws cloudformation delete-stack \
-      --stack-name $STACK_NAME-Event-Rules \
-      --region $REGION
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
 
     echo "Stack deletion initiated. Waiting for deletion to complete..."
 
     # Wait for the stack deletion to complete
     aws cloudformation wait stack-delete-complete \
-      --stack-name $STACK_NAME-Event-Rules \
-      --region $REGION
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
 
     echo "Stack deletion completed."
     exit 1

--- a/infrastructure/gitsync-core/step-2/env/development/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-2/env/development/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-2
-      - ./deploy.sh GitSyncNotifications eu-west-2 observability-infrastructure

--- a/infrastructure/gitsync-core/step-2/env/non-production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-2/env/non-production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-2
-      - ./deploy.sh GitSyncNotifications eu-west-2 observability-infrastructure

--- a/infrastructure/gitsync-core/step-2/env/production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-2/env/production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-2
-      - ./deploy.sh GitSyncNotifications eu-west-2 observability-infrastructure

--- a/infrastructure/gitsync-core/step-3/deploy.sh
+++ b/infrastructure/gitsync-core/step-3/deploy.sh
@@ -3,31 +3,26 @@
 # assigns them to variables and uses them as input parameters to the deploy
 # command for the slack integration template.
 
-STACK_NAME=$1
-SLACK_CHANNEL_ID=$2
-SLACK_WORKSPACE_ID=$3
-REGION=eu-west-2
-
 echo "INFO: collecting topic ARN from: eu-west-2"
 TOPIC_ARN_EU_WEST_2=$(
   aws cloudformation describe-stacks \
   --region eu-west-2 \
-  --stack-name ${STACK_NAME}-Event-Rules \
-  --query 'Stacks[0].Outputs[?OutputKey==`BuildNotificationsEventsSnsTopic`].OutputValue' \
+  --stack-name "${EVENT_RULES_STACK_NAME}" \
+  --query "Stacks[0].Outputs[?OutputKey=='BuildNotificationsEventsSnsTopic'].OutputValue" \
   --output text
   )
 echo "INFO: successfully collected topic ARN from eu-west-2: ${TOPIC_ARN_EU_WEST_2}"
 
 echo "INFO: deploying slack integration stack"
 aws cloudformation deploy \
-    --stack-name ${STACK_NAME}-Slack-Integration \
+    --stack-name "${STACK_NAME}" \
     --template-file slack-integration.yaml \
     --capabilities CAPABILITY_NAMED_IAM \
-    --region $REGION \
+    --region "$REGION" \
     --parameter-overrides \
-      EventTopicsList=${TOPIC_ARN_EU_WEST_2} \
-      SlackChannelId=${SLACK_CHANNEL_ID} \
-      SlackWorkspaceId=${SLACK_WORKSPACE_ID}
+      EventTopicsList="${TOPIC_ARN_EU_WEST_2}" \
+      SlackChannelId="${SLACK_CHANNEL_ID}" \
+      SlackWorkspaceId="${SLACK_WORKSPACE_ID}"
 
 echo "STATUS: Stack deploy complete."
 echo "INFO: Scanning stack health."
@@ -36,8 +31,8 @@ echo "INFO: Scanning stack health."
 # Poll the status until it reaches a completion or failure state
 while true; do
   STATUS=$(aws cloudformation describe-stacks \
-    --stack-name $STACK_NAME-Slack-Integration \
-    --region $REGION \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
     --query "Stacks[0].StackStatus" \
     --output text)
 
@@ -49,15 +44,15 @@ while true; do
     echo "Attempting to delete the failed stack..."
 
     aws cloudformation delete-stack \
-      --stack-name $STACK_NAME-Slack-Integration \
-      --region $REGION
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
 
     echo "Stack deletion initiated. Waiting for deletion to complete..."
 
     # Wait for the stack deletion to complete
     aws cloudformation wait stack-delete-complete \
-      --stack-name $STACK_NAME-Slack-Integration \
-      --region $REGION
+      --stack-name "$STACK_NAME" \
+      --region "$REGION"
 
     echo "Stack deletion completed."
     exit 1

--- a/infrastructure/gitsync-core/step-3/env/development/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-3/env/development/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-3
-      - ./deploy.sh GitSyncNotifications C06PP0YR7PB T8GT9416G

--- a/infrastructure/gitsync-core/step-3/env/non-production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-3/env/non-production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-3
-      - ./deploy.sh GitSyncNotifications C082BA5QNCB T8GT9416G

--- a/infrastructure/gitsync-core/step-3/env/production/build-spec.yaml
+++ b/infrastructure/gitsync-core/step-3/env/production/build-spec.yaml
@@ -1,6 +1,0 @@
-version: 0.2
-phases:
-  build:
-    commands:
-      - cd infrastructure/gitsync-core/step-3
-      - ./deploy.sh GitSyncNotifications C082BA5QNCB T8GT9416G


### PR DESCRIPTION
This looks like quite a meaty change, but is essentially just moving the definition of the Codebuild job configuration parameters out of being hardcoded in the individual build-spec files, to the top level pipeline parameters. 

This means:
- the parameters are only defined in once place
- we have an env-specific parameter set which can serve as the trigger directory for each environment's pipeline (follow up PR for that)
- we no longer need env-specific build-spec files for each step, reducing repo duplication and clutter
- the `deploy.sh` scripts can stay largely the same, they are just changed to pull the relevant parameters from environment variables (passed in via the codepipeline build-spec definitions) instead of positional parameters. The rest of the changes are basically making sure variables are properly quoted

Applied and tested in development         - ✅ 
Redeploy from scratch in development  - ⌛ 
[Applied and tested in non-prod ](TBC) - ⌛ 

Applied in production - will be done post approval and merge to main - ⌛ 