### PR TITLE
Change ownership of repository code from FOG to observability

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/fog
+* @govuk-one-login/observability


### PR DESCRIPTION
The observability team has taken over responsibility for our Dynatrace estate from FOG. Work item: https://govukverify.atlassian.net/browse/PSREOBS-255