### PR TITLE
Rightsize ingested cloudwatch metrics

### DIFF
--- a/infrastructure/non-production/aws-metric-streams-client/template.yaml
+++ b/infrastructure/non-production/aws-metric-streams-client/template.yaml
@@ -132,6 +132,27 @@ Resources:
     Type: AWS::CloudWatch::MetricStream
     Properties:
       FirehoseArn: !GetAtt FirehoseMetricStreams.Arn
+      IncludeFilters:
+        - Namespace: Authentication
+        - Namespace: backend-api
+        - Namespace: CIMIT
+        - Namespace: CrsBackend
+        - Namespace: di-ipv-cri-check-hmrc-api
+        - Namespace: F2F-CRI
+        - Namespace: mob-async-backend
+        - Namespace: TxMA
+        - Namespace: AWS/ApiGateway
+        - Namespace: AWS/ApplicationELB
+        - Namespace: AWS/CodeBuild
+        - Namespace: AWS/DynamoDB
+        - Namespace: AWS/ECS
+        - Namespace: AWS/Firehose
+        - Namespace: AWS/KMS
+        - Namespace: AWS/Lambda
+        - Namespace: AWS/SNS
+        - Namespace: AWS/SQS
+        - Namespace: AWS/States
+        - Namespace: AWS/WAFV2
       IncludeLinkedAccountsMetrics: true
       RoleArn: !GetAtt MetricStreamsRole.Arn
       OutputFormat: 'opentelemetry0.7'

--- a/infrastructure/non-production/aws-metric-streams-client/template.yaml
+++ b/infrastructure/non-production/aws-metric-streams-client/template.yaml
@@ -133,6 +133,7 @@ Resources:
     Properties:
       FirehoseArn: !GetAtt FirehoseMetricStreams.Arn
       IncludeFilters:
+        - Namespace: LambdaInsights
         - Namespace: Authentication
         - Namespace: backend-api
         - Namespace: CIMIT


### PR DESCRIPTION
Audit confirms active LambdaInsights telemetry (Cold Starts/Memory). Added to IncludeFilters to prevent data loss in Dynatrace alongside existing custom and AWS namespaces.

<img width="1696" height="862" alt="image" src="https://github.com/user-attachments/assets/c7067e94-359d-421a-af89-7f58e079d5c5" />
